### PR TITLE
Allow setting secure flag when request served through proxy.

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"github.com/savsgio/gotils"
+	"github.com/valyala/fasthttp"
 )
 
 // NewDefaultConfig return new default configuration
@@ -22,6 +23,9 @@ func NewDefaultConfig() *Config {
 	// default sessionIdGeneratorFunc
 	config.SessionIDGeneratorFunc = config.defaultSessionIDGenerator
 
+	// default isSecureFunc
+	config.IsSecureFunc = config.defaultIsSecureFunc
+
 	return config
 }
 
@@ -31,4 +35,8 @@ func (c *Config) defaultSessionIDGenerator() []byte {
 	gotils.RandBytes(b)
 
 	return b
+}
+
+func (c *Config) defaultIsSecureFunc(ctx *fasthttp.RequestCtx) bool {
+	return ctx.IsTLS()
 }

--- a/cookie.go
+++ b/cookie.go
@@ -34,7 +34,7 @@ func (c *Cookie) Set(ctx *fasthttp.RequestCtx, name string, value []byte, domain
 		}
 	}
 
-	if ctx.IsTLS() && secure {
+	if secure {
 		cookie.SetSecure(true)
 	}
 

--- a/session.go
+++ b/session.go
@@ -45,6 +45,10 @@ func New(cfg *Config) *Session {
 		cfg.SessionIDGeneratorFunc = cfg.defaultSessionIDGenerator
 	}
 
+	if cfg.IsSecureFunc == nil {
+		cfg.IsSecureFunc = cfg.defaultIsSecureFunc
+	}
+
 	session := &Session{
 		config: cfg,
 		cookie: NewCookie(),
@@ -92,7 +96,8 @@ func (s *Session) startGC() {
 }
 
 func (s *Session) setHTTPValues(ctx *fasthttp.RequestCtx, sessionID []byte) {
-	s.cookie.Set(ctx, s.config.CookieName, sessionID, s.config.Domain, s.config.Expires, s.config.Secure)
+	secure := s.config.Secure && s.config.IsSecureFunc(ctx)
+	s.cookie.Set(ctx, s.config.CookieName, sessionID, s.config.Domain, s.config.Expires, secure)
 
 	if s.config.SessionIDInHTTPHeader {
 		ctx.Request.Header.SetBytesV(s.config.SessionNameInHTTPHeader, sessionID)

--- a/types.go
+++ b/types.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/valyala/fasthttp"
+
 	"github.com/savsgio/dictpool"
 	"github.com/savsgio/gotils/dao"
 )
@@ -44,6 +46,10 @@ type Config struct {
 
 	// SessionIDGeneratorFunc should returns a random session id.
 	SessionIDGeneratorFunc func() []byte
+
+	// IsSecureFunc should return whether the communication channel is secure
+	// in order to set the secure flag to true according to Secure flag.
+	IsSecureFunc func(*fasthttp.RequestCtx) bool
 
 	// value cookie length
 	cookieLen uint32


### PR DESCRIPTION
If the communication between the proxy and fasthttp is not over TLS, for
instance when both are on the same host, the secure flag could still be
legitimately set given the proxy does the TLS termination.

TrustedNets configuration option is introduced to specify a list of trusted
networks or IPs from which X-Forwarded-Proto header can be trusted. If
X-Forwarded-Proto coming from a trusted network is set to 'https' and the
Secure configuration flag is set to true, then the cookie secure flag is set
to true.