### PR TITLE
Set expiration per session.

### DIFF
--- a/const.go
+++ b/const.go
@@ -10,3 +10,5 @@ const defaultSecure = true
 const defaultSessionIDInURLQuery = false
 const defaultSessionIDInHTTPHeader = false
 const defaultCookieLen uint32 = 32
+
+const expirationAttributeKey = "__fasthttp_session_expiration__"

--- a/examples/handle.go
+++ b/examples/handle.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/valyala/fasthttp"
 )
@@ -152,4 +153,36 @@ func regenerateHandler(ctx *fasthttp.RequestCtx) {
 
 	ctx.SetBodyString("Session REGENERATE: New session id: ")
 	ctx.Write(sessionID)
+}
+
+// get expiration handler
+func getExpirationHandler(ctx *fasthttp.RequestCtx) {
+	store, err := serverSession.Get(ctx)
+	if err != nil {
+		ctx.Error(err.Error(), fasthttp.StatusInternalServerError)
+		return
+	}
+
+	expiration := store.GetExpiration()
+
+	ctx.SetBodyString("Session Expiration: ")
+	ctx.WriteString(expiration.String())
+}
+
+// set expiration handler
+func setExpirationHandler(ctx *fasthttp.RequestCtx) {
+	store, err := serverSession.Get(ctx)
+	if err != nil {
+		ctx.Error(err.Error(), fasthttp.StatusInternalServerError)
+		return
+	}
+	defer serverSession.Save(ctx, store)
+
+	err = store.SetExpiration(30 * time.Second)
+	if err != nil {
+		ctx.Error(err.Error(), fasthttp.StatusInternalServerError)
+		return
+	}
+
+	ctx.SetBodyString("Session Expiration set to 30 seconds")
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -72,6 +72,8 @@ func main() {
 	r.GET("/destroy", destroyHandler)
 	r.GET("/sessionid", sessionIDHandler)
 	r.GET("/regenerate", regenerateHandler)
+	r.GET("/setexpiration", setExpirationHandler)
+	r.GET("/getexpiration", getExpirationHandler)
 
 	addr := "0.0.0.0:8086"
 	log.Println("Session example server listen: http://" + addr)

--- a/memcache/errors.go
+++ b/memcache/errors.go
@@ -5,3 +5,4 @@ import "errors"
 var errInvalidProviderConfig = errors.New("Invalid provider config")
 var errConfigServerListEmpty = errors.New("Config ServerList must not be empty")
 var errConfigMaxIdleConnsZero = errors.New("Config MaxIdleConns must be more than 0")
+var errExpirationIsTooBig = errors.New("Expiration duration should be a 32 bits value")

--- a/memcache/provider.go
+++ b/memcache/provider.go
@@ -110,7 +110,7 @@ func (mcp *Provider) getMemCacheSessionKey(sessionID []byte) string {
 
 // Get read session store by session id
 func (mcp *Provider) Get(sessionID []byte) (session.Storer, error) {
-	var store *Store
+	store := mcp.acquireStore(sessionID, mcp.expiration)
 	key := mcp.getMemCacheSessionKey(sessionID)
 
 	item, err := mcp.db.Get(key)
@@ -119,14 +119,10 @@ func (mcp *Provider) Get(sessionID []byte) (session.Storer, error) {
 	}
 
 	if item != nil { // Exist
-		store = mcp.acquireStore(sessionID, time.Duration(item.Expiration)*time.Second)
-
 		err := mcp.config.UnSerializeFunc(store.DataPointer(), item.Value)
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		store = mcp.acquireStore(sessionID, mcp.expiration)
 	}
 
 	releaseItem(item)

--- a/memcache/store.go
+++ b/memcache/store.go
@@ -16,12 +16,7 @@ func (mcs *Store) Save() error {
 	item := acquireItem()
 	item.Key = provider.getMemCacheSessionKey(mcs.GetSessionID())
 	item.Value = value
-
-	expiration := mcs.GetExpiration()
-	if expiration > math.MaxInt32 {
-		return errExpirationIsTooBig
-	}
-	item.Expiration = int32(expiration)
+	item.Expiration = int32(mcs.GetExpiration() / time.Second)
 
 	err = provider.db.Set(item)
 
@@ -30,27 +25,10 @@ func (mcs *Store) Save() error {
 	return err
 }
 
-// Init initialize the store
-func (mcs *Store) Init(sessionID []byte, expiration time.Duration) {
-	mcs.newExpiration = expiration
-	mcs.Store.Init(sessionID, expiration)
-}
-
 // SetExpiration set the expiration for the session
 func (mcs *Store) SetExpiration(expiration time.Duration) error {
-	if expiration > math.MaxInt32 {
+	if expiration/time.Second > math.MaxInt32 {
 		return errExpirationIsTooBig
 	}
-	mcs.newExpiration = expiration
-	return nil
-}
-
-// GetExpiration get the expiration for the session
-func (mcs *Store) GetExpiration() time.Duration {
-	return mcs.newExpiration
-}
-
-// HasExpirationChanged return whether the expiration has been updated by the user.
-func (mcs *Store) HasExpirationChanged() bool {
-	return mcs.newExpiration != mcs.Store.GetExpiration()
+	return mcs.Store.SetExpiration(expiration)
 }

--- a/memcache/store.go
+++ b/memcache/store.go
@@ -1,5 +1,10 @@
 package memcache
 
+import (
+	"math"
+	"time"
+)
+
 // Save save store
 func (mcs *Store) Save() error {
 	data := mcs.GetAll()
@@ -11,11 +16,41 @@ func (mcs *Store) Save() error {
 	item := acquireItem()
 	item.Key = provider.getMemCacheSessionKey(mcs.GetSessionID())
 	item.Value = value
-	item.Expiration = provider.expiration
+
+	expiration := mcs.GetExpiration()
+	if expiration > math.MaxInt32 {
+		return errExpirationIsTooBig
+	}
+	item.Expiration = int32(expiration)
 
 	err = provider.db.Set(item)
 
 	releaseItem(item)
 
 	return err
+}
+
+// Init initialize the store
+func (mcs *Store) Init(sessionID []byte, expiration time.Duration) {
+	mcs.newExpiration = expiration
+	mcs.Store.Init(sessionID, expiration)
+}
+
+// SetExpiration set the expiration for the session
+func (mcs *Store) SetExpiration(expiration time.Duration) error {
+	if expiration > math.MaxInt32 {
+		return errExpirationIsTooBig
+	}
+	mcs.newExpiration = expiration
+	return nil
+}
+
+// GetExpiration get the expiration for the session
+func (mcs *Store) GetExpiration() time.Duration {
+	return mcs.newExpiration
+}
+
+// HasExpirationChanged return whether the expiration has been updated by the user.
+func (mcs *Store) HasExpirationChanged() bool {
+	return mcs.newExpiration != mcs.Store.GetExpiration()
 }

--- a/memcache/types.go
+++ b/memcache/types.go
@@ -43,6 +43,4 @@ type Provider struct {
 // Store store struct
 type Store struct {
 	session.Store
-
-	newExpiration time.Duration
 }

--- a/memcache/types.go
+++ b/memcache/types.go
@@ -2,6 +2,7 @@ package memcache
 
 import (
 	"sync"
+	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/fasthttp/session"
@@ -34,7 +35,7 @@ type Config struct {
 type Provider struct {
 	config     *Config
 	db         *memcache.Client
-	expiration int32
+	expiration time.Duration
 
 	storePool sync.Pool
 }
@@ -42,4 +43,6 @@ type Provider struct {
 // Store store struct
 type Store struct {
 	session.Store
+
+	newExpiration time.Duration
 }

--- a/memory/types.go
+++ b/memory/types.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"sync"
+	"time"
 
 	"github.com/fasthttp/session"
 )
@@ -13,7 +14,7 @@ type Config struct{}
 type Provider struct {
 	config     *Config
 	memoryDB   *session.Dict
-	expiration int64
+	expiration time.Duration
 
 	storePool sync.Pool
 

--- a/mysql/dao.go
+++ b/mysql/dao.go
@@ -42,13 +42,13 @@ func NewDao(driver, dsn, tableName string) (*Dao, error) {
 	var err error
 	db.Connection, err = sql.Open(db.Driver, db.Dsn)
 
-	db.sqlGetSessionBySessionID = fmt.Sprintf("SELECT session_id,contents,last_active FROM %s WHERE session_id=?", tableName)
+	db.sqlGetSessionBySessionID = fmt.Sprintf("SELECT session_id,contents,last_active,expiration FROM %s WHERE session_id=?", tableName)
 	db.sqlCountSessions = fmt.Sprintf("SELECT count(*) as total FROM %s", tableName)
-	db.sqlUpdateBySessionID = fmt.Sprintf("UPDATE %s SET contents=?,last_active=? WHERE session_id=?", tableName)
+	db.sqlUpdateBySessionID = fmt.Sprintf("UPDATE %s SET contents=?,last_active=?,expiration=? WHERE session_id=?", tableName)
 	db.sqlDeleteBySessionID = fmt.Sprintf("DELETE FROM %s WHERE session_id=?", tableName)
-	db.sqldeleteSessionByExpiration = fmt.Sprintf("DELETE FROM %s WHERE last_active<=?", tableName)
+	db.sqlDeleteExpiredSessions = fmt.Sprintf("DELETE FROM %s WHERE last_active+expiration<=? AND expiration<>0", tableName)
 	db.sqlInsert = fmt.Sprintf("INSERT INTO %s (session_id, contents, last_active) VALUES (?,?,?)", tableName)
-	db.sqlRegenerate = fmt.Sprintf("UPDATE %s SET session_id=?,last_active=? WHERE session_id=?", tableName)
+	db.sqlRegenerate = fmt.Sprintf("UPDATE %s SET session_id=?,last_active=?,expiration=? WHERE session_id=?", tableName)
 
 	return db, err
 }
@@ -62,7 +62,7 @@ func (db *Dao) getSessionBySessionID(sessionID []byte) (*DBRow, error) {
 		return nil, err
 	}
 
-	err = row.Scan(&data.sessionID, &data.contents, &data.lastActive)
+	err = row.Scan(&data.sessionID, &data.contents, &data.lastActive, &data.expiration)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (db *Dao) countSessions() int {
 }
 
 // update session by sessionID
-func (db *Dao) updateBySessionID(sessionID, contents []byte, lastActiveTime int64) (int64, error) {
-	return db.Exec(db.sqlUpdateBySessionID, gotils.B2S(contents), lastActiveTime, gotils.B2S(sessionID))
+func (db *Dao) updateBySessionID(sessionID, contents []byte, lastActiveTime int64, expiration time.Duration) (int64, error) {
+	return db.Exec(db.sqlUpdateBySessionID, gotils.B2S(contents), lastActiveTime, expiration, gotils.B2S(sessionID))
 }
 
 // delete session by sessionID
@@ -97,17 +97,16 @@ func (db *Dao) deleteBySessionID(sessionID []byte) (int64, error) {
 }
 
 // delete session by expiration
-func (db *Dao) deleteSessionByExpiration(expiration int64) (int64, error) {
-	lastTime := time.Now().Unix() - expiration
-	return db.Exec(db.sqldeleteSessionByExpiration, lastTime)
+func (db *Dao) deleteExpiredSessions() (int64, error) {
+	return db.Exec(db.sqlDeleteExpiredSessions, time.Now().Unix())
 }
 
 // insert new session
-func (db *Dao) insert(sessionID, contents []byte, lastActiveTime int64) (int64, error) {
-	return db.Exec(db.sqlInsert, gotils.B2S(sessionID), gotils.B2S(contents), lastActiveTime)
+func (db *Dao) insert(sessionID, contents []byte, lastActiveTime int64, expiration time.Duration) (int64, error) {
+	return db.Exec(db.sqlInsert, gotils.B2S(sessionID), gotils.B2S(contents), lastActiveTime, expiration)
 }
 
 // insert new session
-func (db *Dao) regenerate(oldID, newID []byte, lastActiveTime int64) (int64, error) {
+func (db *Dao) regenerate(oldID, newID []byte, lastActiveTime int64, expiration time.Duration) (int64, error) {
 	return db.Exec(db.sqlRegenerate, gotils.B2S(newID), lastActiveTime, gotils.B2S(oldID))
 }

--- a/mysql/store.go
+++ b/mysql/store.go
@@ -12,7 +12,7 @@ func (ms *Store) Save() error {
 		return err
 	}
 
-	_, err = provider.db.updateBySessionID(ms.GetSessionID(), value, time.Now().Unix())
+	_, err = provider.db.updateBySessionID(ms.GetSessionID(), value, time.Now().Unix(), ms.GetExpiration())
 
 	return err
 }

--- a/mysql/table.sql
+++ b/mysql/table.sql
@@ -4,6 +4,8 @@ CREATE TABLE IF NOT EXISTS `session` (
    `session_id` varchar(64) NOT NULL DEFAULT '' COMMENT 'Session id',
    `contents` TEXT NOT NULL COMMENT 'Session data',
    `last_active` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Last active time',
+   `expiration` int(10) unsigned NOT NULL DEFAULT '0' COMMENT 'Expiration time',
    PRIMARY KEY (`session_id`),
-   KEY `last_active` (`last_active`)
+   KEY `last_active` (`last_active`),
+   KEY `expiration` (`expiration`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='session table';

--- a/mysql/types.go
+++ b/mysql/types.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"sync"
+	"time"
 
 	"github.com/fasthttp/session"
 )
@@ -59,7 +60,7 @@ type Config struct {
 type Provider struct {
 	config     *Config
 	db         *Dao
-	expiration int64
+	expiration time.Duration
 
 	storePool sync.Pool
 }
@@ -75,18 +76,19 @@ type Dao struct {
 
 	tableName string
 
-	sqlGetSessionBySessionID     string
-	sqlCountSessions             string
-	sqlUpdateBySessionID         string
-	sqlDeleteBySessionID         string
-	sqldeleteSessionByExpiration string
-	sqlInsert                    string
-	sqlRegenerate                string
+	sqlGetSessionBySessionID string
+	sqlCountSessions         string
+	sqlUpdateBySessionID     string
+	sqlDeleteBySessionID     string
+	sqlDeleteExpiredSessions string
+	sqlInsert                string
+	sqlRegenerate            string
 }
 
 // DBRow database row definition
 type DBRow struct {
 	sessionID  string
 	contents   string
-	lastActive int
+	lastActive int64
+	expiration time.Duration
 }

--- a/postgres/dao.go
+++ b/postgres/dao.go
@@ -66,6 +66,7 @@ func (db *Dao) getSessionBySessionID(sessionID []byte) (*DBRow, error) {
 	if err != nil && err != sql.ErrNoRows {
 		return nil, err
 	}
+	data.expiration *= time.Second
 
 	return data, nil
 }
@@ -88,7 +89,7 @@ func (db *Dao) countSessions() int {
 
 // update session by sessionID
 func (db *Dao) updateBySessionID(sessionID, contents []byte, lastActiveTime int64, expiration time.Duration) (int64, error) {
-	return db.Exec(db.sqlUpdateBySessionID, gotils.B2S(contents), lastActiveTime, expiration, gotils.B2S(sessionID))
+	return db.Exec(db.sqlUpdateBySessionID, gotils.B2S(contents), lastActiveTime, expiration/time.Second, gotils.B2S(sessionID))
 }
 
 // delete session by sessionID
@@ -103,10 +104,10 @@ func (db *Dao) deleteExpiredSessions() (int64, error) {
 
 // insert new session
 func (db *Dao) insert(sessionID, contents []byte, lastActiveTime int64, expiration time.Duration) (int64, error) {
-	return db.Exec(db.sqlInsert, gotils.B2S(sessionID), gotils.B2S(contents), lastActiveTime, expiration)
+	return db.Exec(db.sqlInsert, gotils.B2S(sessionID), gotils.B2S(contents), lastActiveTime, expiration/time.Second)
 }
 
 // insert new session
 func (db *Dao) regenerate(oldID, newID []byte, lastActiveTime int64, expiration time.Duration) (int64, error) {
-	return db.Exec(db.sqlRegenerate, gotils.B2S(newID), lastActiveTime, expiration, gotils.B2S(oldID))
+	return db.Exec(db.sqlRegenerate, gotils.B2S(newID), lastActiveTime, expiration/time.Second, gotils.B2S(oldID))
 }

--- a/postgres/dao.go
+++ b/postgres/dao.go
@@ -42,13 +42,13 @@ func NewDao(driver, dsn, tableName string) (*Dao, error) {
 	var err error
 	db.Connection, err = sql.Open(db.Driver, db.Dsn)
 
-	db.sqlGetSessionBySessionID = fmt.Sprintf("SELECT session_id,contents,last_active FROM %s WHERE session_id=$1", tableName)
+	db.sqlGetSessionBySessionID = fmt.Sprintf("SELECT session_id,contents,last_active,expiration FROM %s WHERE session_id=$1", tableName)
 	db.sqlCountSessions = fmt.Sprintf("SELECT count(*) as total FROM %s", tableName)
-	db.sqlUpdateBySessionID = fmt.Sprintf("UPDATE %s SET contents=$1,last_active=$2 WHERE session_id=$3", tableName)
+	db.sqlUpdateBySessionID = fmt.Sprintf("UPDATE %s SET contents=$1,last_active=$2,expiration=$3 WHERE session_id=$4", tableName)
 	db.sqlDeleteBySessionID = fmt.Sprintf("DELETE FROM %s WHERE session_id=$1", tableName)
-	db.sqldeleteSessionByExpiration = fmt.Sprintf("DELETE FROM %s WHERE last_active<=$1", tableName)
-	db.sqlInsert = fmt.Sprintf("INSERT INTO %s (session_id, contents, last_active) VALUES ($1,$2,$3)", tableName)
-	db.sqlRegenerate = fmt.Sprintf("UPDATE %s SET session_id=$1,last_active=$2 WHERE session_id=$3", tableName)
+	db.sqlDeleteExpiredSessions = fmt.Sprintf("DELETE FROM %s WHERE last_active+expiration<=$1 AND expiration<>0", tableName)
+	db.sqlInsert = fmt.Sprintf("INSERT INTO %s (session_id, contents, last_active, expiration) VALUES ($1,$2,$3,$4)", tableName)
+	db.sqlRegenerate = fmt.Sprintf("UPDATE %s SET session_id=$1,last_active=$2,expiration=$3 WHERE session_id=$4", tableName)
 
 	return db, err
 }
@@ -62,7 +62,7 @@ func (db *Dao) getSessionBySessionID(sessionID []byte) (*DBRow, error) {
 		return nil, err
 	}
 
-	err = row.Scan(&data.sessionID, &data.contents, &data.lastActive)
+	err = row.Scan(&data.sessionID, &data.contents, &data.lastActive, &data.expiration)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (db *Dao) countSessions() int {
 }
 
 // update session by sessionID
-func (db *Dao) updateBySessionID(sessionID, contents []byte, lastActiveTime int64) (int64, error) {
-	return db.Exec(db.sqlUpdateBySessionID, gotils.B2S(contents), lastActiveTime, gotils.B2S(sessionID))
+func (db *Dao) updateBySessionID(sessionID, contents []byte, lastActiveTime int64, expiration time.Duration) (int64, error) {
+	return db.Exec(db.sqlUpdateBySessionID, gotils.B2S(contents), lastActiveTime, expiration, gotils.B2S(sessionID))
 }
 
 // delete session by sessionID
@@ -97,17 +97,16 @@ func (db *Dao) deleteBySessionID(sessionID []byte) (int64, error) {
 }
 
 // delete session by expiration
-func (db *Dao) deleteSessionByExpiration(expiration int64) (int64, error) {
-	lastTime := time.Now().Unix() - expiration
-	return db.Exec(db.sqldeleteSessionByExpiration, lastTime)
+func (db *Dao) deleteExpiredSessions() (int64, error) {
+	return db.Exec(db.sqlDeleteExpiredSessions, time.Now().Unix())
 }
 
 // insert new session
-func (db *Dao) insert(sessionID, contents []byte, lastActiveTime int64) (int64, error) {
-	return db.Exec(db.sqlInsert, gotils.B2S(sessionID), gotils.B2S(contents), lastActiveTime)
+func (db *Dao) insert(sessionID, contents []byte, lastActiveTime int64, expiration time.Duration) (int64, error) {
+	return db.Exec(db.sqlInsert, gotils.B2S(sessionID), gotils.B2S(contents), lastActiveTime, expiration)
 }
 
 // insert new session
-func (db *Dao) regenerate(oldID, newID []byte, lastActiveTime int64) (int64, error) {
-	return db.Exec(db.sqlRegenerate, gotils.B2S(newID), lastActiveTime, gotils.B2S(oldID))
+func (db *Dao) regenerate(oldID, newID []byte, lastActiveTime int64, expiration time.Duration) (int64, error) {
+	return db.Exec(db.sqlRegenerate, gotils.B2S(newID), lastActiveTime, expiration, gotils.B2S(oldID))
 }

--- a/postgres/store.go
+++ b/postgres/store.go
@@ -12,7 +12,7 @@ func (ps *Store) Save() error {
 		return err
 	}
 
-	_, err = provider.db.updateBySessionID(ps.GetSessionID(), value, time.Now().Unix())
+	_, err = provider.db.updateBySessionID(ps.GetSessionID(), value, time.Now().Unix(), ps.GetExpiration())
 
 	return err
 }

--- a/postgres/table.sql
+++ b/postgres/table.sql
@@ -3,7 +3,9 @@ DROP TABLE IF EXISTS session;
 CREATE TABLE IF NOT EXISTS session (
   session_id VARCHAR(64) PRIMARY KEY NOT NULL DEFAULT '',
   contents TEXT NOT NULL,
-  last_active INT NOT NULL DEFAULT '0'
+  last_active INT NOT NULL DEFAULT '0',
+  expiration INT NOT NULL DEFAULT '0'
 );
 
 CREATE INDEX last_active ON SESSION (last_active);
+CREATE INDEX expiration ON SESSION (expiration);

--- a/postgres/types.go
+++ b/postgres/types.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"sync"
+	"time"
 
 	"github.com/fasthttp/session"
 )
@@ -48,7 +49,7 @@ type Config struct {
 type Provider struct {
 	config     *Config
 	db         *Dao
-	expiration int64
+	expiration time.Duration
 
 	storePool sync.Pool
 }
@@ -64,18 +65,19 @@ type Dao struct {
 
 	tableName string
 
-	sqlGetSessionBySessionID     string
-	sqlCountSessions             string
-	sqlUpdateBySessionID         string
-	sqlDeleteBySessionID         string
-	sqldeleteSessionByExpiration string
-	sqlInsert                    string
-	sqlRegenerate                string
+	sqlGetSessionBySessionID string
+	sqlCountSessions         string
+	sqlUpdateBySessionID     string
+	sqlDeleteBySessionID     string
+	sqlDeleteExpiredSessions string
+	sqlInsert                string
+	sqlRegenerate            string
 }
 
 // DBRow database row definition
 type DBRow struct {
 	sessionID  string
 	contents   string
-	lastActive int
+	lastActive int64
+	expiration time.Duration
 }

--- a/redis/store.go
+++ b/redis/store.go
@@ -8,7 +8,7 @@ func (rs *Store) Save() error {
 		return err
 	}
 
-	err = provider.db.Set(provider.getRedisSessionKey(rs.GetSessionID()), b, provider.expiration).Err()
+	err = provider.db.Set(provider.getRedisSessionKey(rs.GetSessionID()), b, rs.GetExpiration()).Err()
 
 	return err
 }

--- a/sqlite3/dao.go
+++ b/sqlite3/dao.go
@@ -67,6 +67,8 @@ func (db *Dao) getSessionBySessionID(sessionID []byte) (*DBRow, error) {
 		return nil, err
 	}
 
+	data.expiration *= time.Second
+
 	return data, nil
 }
 
@@ -88,7 +90,7 @@ func (db *Dao) countSessions() int {
 
 // update session by sessionID
 func (db *Dao) updateBySessionID(sessionID, contents []byte, lastActiveTime int64, expiration time.Duration) (int64, error) {
-	return db.Exec(db.sqlUpdateBySessionID, gotils.B2S(contents), lastActiveTime, expiration, gotils.B2S(sessionID))
+	return db.Exec(db.sqlUpdateBySessionID, gotils.B2S(contents), lastActiveTime, expiration/time.Second, gotils.B2S(sessionID))
 }
 
 // delete session by sessionID
@@ -103,10 +105,10 @@ func (db *Dao) deleteExpiredSessions() (int64, error) {
 
 // insert new session
 func (db *Dao) insert(sessionID, contents []byte, lastActiveTime int64, expiration time.Duration) (int64, error) {
-	return db.Exec(db.sqlInsert, gotils.B2S(sessionID), gotils.B2S(contents), lastActiveTime, expiration)
+	return db.Exec(db.sqlInsert, gotils.B2S(sessionID), gotils.B2S(contents), lastActiveTime, expiration/time.Second)
 }
 
 // insert new session
 func (db *Dao) regenerate(oldID, newID []byte, lastActiveTime int64, expiration time.Duration) (int64, error) {
-	return db.Exec(db.sqlRegenerate, gotils.B2S(newID), lastActiveTime, expiration, gotils.B2S(oldID))
+	return db.Exec(db.sqlRegenerate, gotils.B2S(newID), lastActiveTime, expiration/time.Second, gotils.B2S(oldID))
 }

--- a/sqlite3/store.go
+++ b/sqlite3/store.go
@@ -12,7 +12,7 @@ func (ss *Store) Save() error {
 		return err
 	}
 
-	_, err = provider.db.updateBySessionID(ss.GetSessionID(), value, time.Now().Unix())
+	_, err = provider.db.updateBySessionID(ss.GetSessionID(), value, time.Now().Unix(), ss.GetExpiration())
 
 	return err
 }

--- a/sqlite3/table.sql
+++ b/sqlite3/table.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS session (
   contents TEXT NOT NULL,
   last_active INT(10) NOT NULL DEFAULT '0',
   expiration INT(10) NOT NULL DEFAULT '0'
-)
+);
 
 CREATE INDEX last_active ON SESSION (last_active);
 CREATE INDEX expiration ON SESSION (expiration);

--- a/sqlite3/table.sql
+++ b/sqlite3/table.sql
@@ -3,7 +3,9 @@ DROP TABLE IF EXISTS session;
 CREATE TABLE IF NOT EXISTS session (
   session_id VARCHAR(64) PRIMARY KEY NOT NULL DEFAULT '',
   contents TEXT NOT NULL,
-  last_active INT(10) NOT NULL DEFAULT '0'
+  last_active INT(10) NOT NULL DEFAULT '0',
+  expiration INT(10) NOT NULL DEFAULT '0'
 )
 
 CREATE INDEX last_active ON SESSION (last_active);
+CREATE INDEX expiration ON SESSION (expiration);

--- a/sqlite3/types.go
+++ b/sqlite3/types.go
@@ -2,6 +2,7 @@ package sqlite3
 
 import (
 	"sync"
+	"time"
 
 	"github.com/fasthttp/session"
 )
@@ -32,7 +33,7 @@ type Config struct {
 type Provider struct {
 	config     *Config
 	db         *Dao
-	expiration int64
+	expiration time.Duration
 
 	storePool sync.Pool
 }
@@ -48,18 +49,19 @@ type Dao struct {
 
 	tableName string
 
-	sqlGetSessionBySessionID     string
-	sqlCountSessions             string
-	sqlUpdateBySessionID         string
-	sqlDeleteBySessionID         string
-	sqldeleteSessionByExpiration string
-	sqlInsert                    string
-	sqlRegenerate                string
+	sqlGetSessionBySessionID string
+	sqlCountSessions         string
+	sqlUpdateBySessionID     string
+	sqlDeleteBySessionID     string
+	sqlDeleteExpiredSessions string
+	sqlInsert                string
+	sqlRegenerate            string
 }
 
 // DBRow database row definition
 type DBRow struct {
 	sessionID  string
 	contents   string
-	lastActive int
+	lastActive int64
+	expiration time.Duration
 }

--- a/store.go
+++ b/store.go
@@ -2,8 +2,6 @@ package session
 
 import "time"
 
-const expirationAttributeKey = "__fasthttp_session_expiration__"
-
 // Init init store data and sessionID
 func (s *Store) Init(sessionID []byte, defaultExpiration time.Duration) {
 	s.sessionID = sessionID
@@ -78,7 +76,9 @@ func (s *Store) SetSessionID(id []byte) {
 
 // SetExpiration set expiration for the session
 func (s *Store) SetExpiration(expiration time.Duration) error {
+	s.lock.Lock()
 	s.expirationChanged = true
+	s.lock.Unlock()
 	s.Set(expirationAttributeKey, int64(expiration.Seconds()))
 	return nil
 }
@@ -94,7 +94,10 @@ func (s *Store) GetExpiration() time.Duration {
 
 // HasExpirationChanged check wether the expiration has been changed
 func (s *Store) HasExpirationChanged() bool {
-	return s.expirationChanged
+	s.lock.RLock()
+	expirationChanged := s.expirationChanged
+	s.lock.RUnlock()
+	return expirationChanged
 }
 
 // Reset reset store

--- a/store.go
+++ b/store.go
@@ -1,8 +1,12 @@
 package session
 
+import "time"
+
 // Init init store data and sessionID
-func (s *Store) Init(sessionID []byte) {
+func (s *Store) Init(sessionID []byte, expiration time.Duration) {
 	s.sessionID = sessionID
+	s.expiration = expiration
+	s.newExpiration = expiration
 
 	if s.data == nil { // Ensure the store always has a valid pointer of Dict
 		s.data = new(Dict)
@@ -69,6 +73,22 @@ func (s *Store) SetSessionID(id []byte) {
 	s.lock.Lock()
 	s.sessionID = id
 	s.lock.Unlock()
+}
+
+// SetExpiration set expiration for the session
+func (s *Store) SetExpiration(expiration time.Duration) error {
+	s.newExpiration = expiration
+	return nil
+}
+
+// GetExpiration get expiration for the session
+func (s *Store) GetExpiration() time.Duration {
+	return s.newExpiration
+}
+
+// HasExpirationChanged check wether the expiration has been changed
+func (s *Store) HasExpirationChanged() bool {
+	return s.expiration != s.newExpiration
 }
 
 // Reset reset store

--- a/types.go
+++ b/types.go
@@ -74,11 +74,11 @@ type Dao struct {
 
 // Store store
 type Store struct {
-	sessionID     []byte
-	data          *Dict
-	expiration    time.Duration
-	newExpiration time.Duration
-	lock          sync.RWMutex
+	sessionID         []byte
+	data              *Dict
+	defaultExpiration time.Duration
+	expirationChanged bool
+	lock              sync.RWMutex
 }
 
 // Encrypt encrypt struct

--- a/types.go
+++ b/types.go
@@ -74,9 +74,11 @@ type Dao struct {
 
 // Store store
 type Store struct {
-	sessionID []byte
-	data      *Dict
-	lock      sync.RWMutex
+	sessionID     []byte
+	data          *Dict
+	expiration    time.Duration
+	newExpiration time.Duration
+	lock          sync.RWMutex
 }
 
 // Encrypt encrypt struct
@@ -97,15 +99,18 @@ type Storer interface {
 	DeleteBytes(key []byte)
 	Flush()
 	GetSessionID() []byte
+	SetExpiration(expiration time.Duration) error
+	GetExpiration() time.Duration
+	HasExpirationChanged() bool
 }
 
 // Provider provider interface
 type Provider interface {
-	Init(expiration int64, cfg ProviderConfig) error
+	Init(expiration time.Duration, cfg ProviderConfig) error
 	Get(id []byte) (Storer, error)
 	Put(store Storer)
 	Destroy(id []byte) error
-	Regenerate(oldID, newID []byte) (Storer, error)
+	Regenerate(oldID, newID []byte) (Storer, error) // the expiration is also reset to original value
 	Count() int
 	NeedGC() bool
 	GC()


### PR DESCRIPTION
In some cases it might be legitimate to override the session expiration. For
instance, in an authentication workflow, one might want to check the
"Remember me" option and in that case the session cookie should not expire
anymore while by default all new cookies should inherit from the default
configuration.

This change will allow a user to call SetExpiration(...) on a storer
so that the new expiration is applied to that session. This updates the cookie
with the new expiration. Please note that the regenerating a session will reset
the expiration to the default value which was globally configured.