### PR TITLE
Set new cookie in request when cookie is regenerated.

### DIFF
--- a/cookie.go
+++ b/cookie.go
@@ -38,6 +38,7 @@ func (c *Cookie) Set(ctx *fasthttp.RequestCtx, name string, value []byte, domain
 		cookie.SetSecure(true)
 	}
 
+	ctx.Request.Header.SetCookieBytesKV(cookie.Key(), cookie.Value())
 	ctx.Response.Header.SetCookie(cookie)
 
 	fasthttp.ReleaseCookie(cookie)


### PR DESCRIPTION
Setting the cookie in the request will help testing code because
the testing code can now verify what is stored in the newly generated cookie
by retrieving the newly created store after the cookie regeneration.

Before this change, it was not possible to retrieve the new store because
the store retrieved using the session ID stored in the cookie coming from the
request.