### PR TITLE
Fix Sqlite3 and Postgres indexing panic

### DIFF
--- a/providers/postgre/provider.go
+++ b/providers/postgre/provider.go
@@ -18,8 +18,8 @@ var (
 		last_active BIGINT NOT NULL DEFAULT '0',
 		expiration BIGINT NOT NULL DEFAULT '0'
 	);`,
-		"CREATE INDEX last_active ON %s (last_active);",
-		"CREATE INDEX expiration ON %s (expiration);",
+		"CREATE INDEX IF NOT EXISTS last_active ON %s (last_active);",
+		"CREATE INDEX IF NOT EXISTS expiration ON %s (expiration);",
 	}
 )
 

--- a/providers/sqlite3/provider.go
+++ b/providers/sqlite3/provider.go
@@ -18,8 +18,8 @@ var (
 		last_active BIGINT NOT NULL DEFAULT '0',
 		expiration BIGINT NOT NULL DEFAULT '0'
 	);`,
-		"CREATE INDEX last_active ON %s (last_active);",
-		"CREATE INDEX expiration ON %s (expiration);",
+		"CREATE INDEX IF NOT EXISTS last_active ON %s (last_active);",
+		"CREATE INDEX IF NOT EXISTS expiration ON %s (expiration);",
 	}
 )
 


### PR DESCRIPTION
By adding `IF NOT EXISTS` to the `initQueries` structure we fix the case of panic, when the user does not remove the previous table by default. 

Caused by this pull request: https://github.com/fasthttp/session/pull/27

Related issue: https://github.com/gofiber/session/issues/13


