### PR TITLE
[BUGFIX] Make Session Attribute Key Non Random

### DIFF
--- a/const.go
+++ b/const.go
@@ -14,3 +14,4 @@ const defaultCookieLen uint32 = 32
 // If set the cookie expiration when the browser is closed (-1), set the expiration as a keep alive (2 days)
 // so as not to keep dead sessions for a long time
 const keepAliveExpiration = 2 * 24 * time.Hour
+const expirationAttrKey = "__store:expiration__"

--- a/store.go
+++ b/store.go
@@ -1,13 +1,8 @@
 package session
 
 import (
-	"fmt"
 	"time"
-
-	"github.com/savsgio/gotils/bytes"
 )
-
-var expirationAttrKey = fmt.Sprintf("__store:expiration:%s__", bytes.Rand(make([]byte, 5)))
 
 // NewStore returns a new empty store
 func NewStore() *Store {


### PR DESCRIPTION
* between v1 and v2 the session expiration attr key became a random value
* this caused sessions generated in one app/daemon/etc to have expirations not aligning with others
* this patch basically restores the functionality found in v1
* fixes #32