### PR TITLE
feat(redis): allow users to set the redis logger easily

### DIFF
--- a/providers/redis/provider.go
+++ b/providers/redis/provider.go
@@ -16,6 +16,8 @@ func New(cfg Config) (*Provider, error) {
 		return nil, errConfigAddrEmpty
 	}
 
+	redis.SetLogger(cfg.Logger)
+
 	db := redis.NewClient(&redis.Options{
 		Network:            cfg.Network,
 		Addr:               cfg.Addr,
@@ -55,6 +57,8 @@ func NewFailover(cfg FailoverConfig) (*Provider, error) {
 	if cfg.MasterName == "" {
 		return nil, errConfigMasterNameEmpty
 	}
+
+	redis.SetLogger(cfg.Logger)
 
 	db := redis.NewFailoverClient(&redis.FailoverOptions{
 		MasterName:         cfg.MasterName,
@@ -96,6 +100,8 @@ func NewFailoverCluster(cfg FailoverConfig) (*Provider, error) {
 	if cfg.MasterName == "" {
 		return nil, errConfigMasterNameEmpty
 	}
+
+	redis.SetLogger(cfg.Logger)
 
 	db := redis.NewFailoverClusterClient(&redis.FailoverOptions{
 		MasterName:         cfg.MasterName,

--- a/providers/redis/provider.go
+++ b/providers/redis/provider.go
@@ -16,7 +16,9 @@ func New(cfg Config) (*Provider, error) {
 		return nil, errConfigAddrEmpty
 	}
 
-	redis.SetLogger(cfg.Logger)
+	if cfg.Logger != nil {
+		redis.SetLogger(cfg.Logger)
+	}
 
 	db := redis.NewClient(&redis.Options{
 		Network:            cfg.Network,
@@ -58,7 +60,9 @@ func NewFailover(cfg FailoverConfig) (*Provider, error) {
 		return nil, errConfigMasterNameEmpty
 	}
 
-	redis.SetLogger(cfg.Logger)
+	if cfg.Logger != nil {
+		redis.SetLogger(cfg.Logger)
+	}
 
 	db := redis.NewFailoverClient(&redis.FailoverOptions{
 		MasterName:         cfg.MasterName,
@@ -101,7 +105,9 @@ func NewFailoverCluster(cfg FailoverConfig) (*Provider, error) {
 		return nil, errConfigMasterNameEmpty
 	}
 
-	redis.SetLogger(cfg.Logger)
+	if cfg.Logger != nil {
+		redis.SetLogger(cfg.Logger)
+	}
 
 	db := redis.NewFailoverClusterClient(&redis.FailoverOptions{
 		MasterName:         cfg.MasterName,

--- a/providers/redis/types.go
+++ b/providers/redis/types.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"context"
 	"crypto/tls"
 	"time"
 
@@ -11,6 +12,9 @@ import (
 type Config struct {
 	// Key prefix
 	KeyPrefix string
+
+	// Pointer to the logger interface.
+	Logger Logger
 
 	// The network type, either tcp or unix.
 	// Default is tcp.
@@ -94,6 +98,9 @@ type Config struct {
 type FailoverConfig struct {
 	// Key prefix
 	KeyPrefix string
+
+	// Pointer to the logger interface.
+	Logger Logger
 
 	// Optional username.
 	Username string
@@ -185,4 +192,9 @@ type FailoverConfig struct {
 type Provider struct {
 	keyPrefix string
 	db        redis.Cmdable
+}
+
+// Logger implements the upstream redis internal Logger interface.
+type Logger interface {
+	Printf(ctx context.Context, format string, v ...interface{})
 }


### PR DESCRIPTION
This is so that users can provide an implementation of the redis internal Logger interface to configure logging.