### PR TITLE
Fix SQL Destroy

### DIFF
--- a/internal/sql/provider.go
+++ b/internal/sql/provider.go
@@ -122,7 +122,7 @@ func (p *Provider) Regenerate(id, newID []byte, expiration time.Duration) error 
 
 // Destroy destroys the session from the given id
 func (p *Provider) Destroy(id []byte) error {
-	_, err := p.Exec(p.config.SQLDestroy, id)
+	_, err := p.Exec(p.config.SQLDestroy, strconv.B2S(id))
 	return err
 }
 


### PR DESCRIPTION
Add missing `strconv.B2S(id)`.  This was causing `Destroy` to not actually work with sqlite3 provider.